### PR TITLE
Query Interfaces

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,0 +1,99 @@
+package riakpbc
+
+// MapReduce executes a MapReduce job.
+//
+// Encodings:
+//
+//    - application/json - JSON-encoded map/reduce job
+//    - application/x-erlang-binary - Erlang external term format
+func (c *Conn) MapReduce(request, contentType string) (response [][]byte, err error) {
+	reqstruct := &RpbMapRedReq{
+		Request:     []byte(request),
+		ContentType: []byte(contentType),
+	}
+
+	err = c.Request(reqstruct, "RpbMapRedReq")
+	if err != nil {
+		return nil, err
+	}
+
+	var rawresp interface{}
+	rawresp, err = c.Response(&RpbMapRedResp{})
+	if err != nil {
+		return nil, err
+	}
+
+	done := rawresp.(*RpbMapRedResp).Done
+	respresp := rawresp.(*RpbMapRedResp).Response
+
+	response = append(response, respresp)
+
+	for done == nil {
+		moreresp, moreerr := c.Response(&RpbMapRedResp{})
+		if moreerr != nil {
+			return nil, moreerr
+		}
+
+		done = moreresp.(*RpbMapRedResp).Done
+		response = append(response, moreresp.(*RpbMapRedResp).Response)
+	}
+
+	return response, nil
+}
+
+// Index requests a set of keys that match a secondary index query.
+//
+//     qtype - an IndexQueryType of either 0 (eq) or 1 (range)
+func (c *Conn) Index(bucket, index string, qtype RpbIndexReq_IndexQueryType, opts *RpbIndexReq) (response RpbIndexResp, err error) {
+	reqstruct := &RpbIndexReq{}
+	if opts != nil {
+		reqstruct = opts
+	}
+	reqstruct.Bucket = []byte(bucket)
+	reqstruct.Index = []byte(index)
+	reqstruct.Qtype = &qtype
+
+	err = c.Request(reqstruct, "RpbIndexReq")
+	if err != nil {
+		return RpbIndexResp{}, err
+	}
+
+	rawresp, err := c.Response(&RpbIndexResp{})
+	if err != nil {
+		return RpbIndexResp{}, err
+	}
+
+	if rawresp != nil {
+		return rawresp.(RpbIndexResp), nil
+	}
+
+	return RpbIndexResp{}, nil
+}
+
+// Search scans bucket for query string q and searches index for the match.
+//
+// RpbSearchQueryReq can be passed in to further enhance the query, otherwise pass nil.
+func (c *Conn) Search(q, index string, opts *RpbSearchQueryReq) (response RpbSearchQueryResp, err error) {
+	reqstruct := &RpbSearchQueryReq{}
+	if opts != nil {
+		reqstruct = opts
+	}
+	reqstruct.Q = []byte(q)
+	reqstruct.Index = []byte(index)
+
+	err = c.Request(reqstruct, "RpbSearchQueryReq")
+	if err != nil {
+		return RpbSearchQueryResp{}, err
+	}
+
+	rawresp, err := c.Response(&RpbSearchQueryResp{})
+	if err != nil {
+		return RpbSearchQueryResp{}, err
+	}
+
+	if rawresp != nil {
+		return rawresp.(RpbSearchQueryResp), nil
+	}
+
+	return RpbSearchQueryResp{}, nil
+}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,68 @@
+package riakpbc
+
+import (
+	"github.com/bmizerany/assert"
+	"os/exec"
+	"testing"
+)
+
+func setupIndexing(t *testing.T) {
+	cmd := exec.Command("search-cmd", "install", "riakpbctestbucket")
+	err := cmd.Run()
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func teardownIndexing(t *testing.T) {
+	cmd := exec.Command("search-cmd", "uninstall", "riakpbctestbucket")
+	err := cmd.Run()
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func TestMapReduce(t *testing.T) {
+	riak := setupConnection(t)
+	setupData(t, riak)
+
+	twoLevelQuery := "{\"inputs\":[[\"riakpbctestbucket\",\"testkey\"]],\"query\":[{\"map\":{\"language\":\"javascript\",\"keep\":false,\"name\":\"Riak.mapValuesJson\"}},{\"reduce\":{\"language\":\"javascript\",\"keep\":true,\"name\":\"Riak.reduceMax\"}}]}"
+	reduced, err := riak.MapReduce(twoLevelQuery, "application/json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	assert.T(t, reduced != nil)
+	assert.T(t, len(reduced) == 2)
+
+	teardownData(t, riak)
+}
+
+func TestIndex(t *testing.T) {
+	riak := setupConnection(t)
+	setupData(t, riak)
+
+	data, err := riak.Index("riakpbctestbucket", "data_bin", 0, &RpbIndexReq{Key: []byte("testkey")})
+	if err != nil {
+		t.Log("In order for this test to pass storage_backend must be set to riak_kv_eleveldb_backend in app.config")
+		t.Error(err.Error())
+	}
+	assert.T(t, len(data.GetKeys()) > 0)
+
+	teardownData(t, riak)
+}
+
+func TestSearch(t *testing.T) {
+	riak := setupConnection(t)
+	setupIndexing(t)
+	setupData(t, riak)
+
+	data, err := riak.Search("*awesome*", "data", nil)
+	if err != nil {
+		t.Log("In order for this test to pass riak_search may need to be enabled in app.config")
+		t.Error(err.Error())
+	}
+	assert.T(t, data.GetNumFound() > 0)
+
+	teardownData(t, riak)
+	teardownIndexing(t)
+}

--- a/riakpbc.go
+++ b/riakpbc.go
@@ -200,42 +200,6 @@ func (c *Conn) SetClientId(clientId string) (response []byte, err error) {
 	return uncoercedresponse.([]byte), nil
 }
 
-// MapReduce
-func (c *Conn) MapReduce(content string) (response [][]byte, err error) {
-	reqstruct := &RpbMapRedReq{
-		Request:     []byte(content),
-		ContentType: []byte("application/json"),
-	}
-
-	err = c.Request(reqstruct, "RpbMapRedReq")
-	if err != nil {
-		return nil, err
-	}
-
-	var rawresp interface{}
-	rawresp, err = c.Response(&RpbMapRedResp{})
-	if err != nil {
-		return nil, err
-	}
-
-	done := rawresp.(*RpbMapRedResp).Done
-	respresp := rawresp.(*RpbMapRedResp).Response
-
-	response = append(response, respresp)
-
-	for done == nil {
-		moreresp, moreerr := c.Response(&RpbMapRedResp{})
-		if moreerr != nil {
-			return nil, moreerr
-		}
-
-		done = moreresp.(*RpbMapRedResp).Done
-		response = append(response, moreresp.(*RpbMapRedResp).Response)
-	}
-
-	return response, nil
-}
-
 // Create bucket
 func (c *Conn) SetBucket(bucket string, nval *uint32, allowmult *bool) (response []byte, err error) {
 	propstruct := &RpbBucketProps{

--- a/riakpbc_test.go
+++ b/riakpbc_test.go
@@ -129,18 +129,3 @@ func TestPing(t *testing.T) {
 	}
 	assert.T(t, string(pong) == "Pong")
 }
-
-func TestMapReduce(t *testing.T) {
-	riak := setupConnection(t)
-	setupData(t, riak)
-
-	twoLevelQuery := "{\"inputs\":[[\"riakpbctestbucket\",\"testkey\"]],\"query\":[{\"map\":{\"language\":\"javascript\",\"keep\":false,\"name\":\"Riak.mapValuesJson\"}},{\"reduce\":{\"language\":\"javascript\",\"keep\":true,\"name\":\"Riak.reduceMax\"}}]}"
-	reduced, err := riak.MapReduce(twoLevelQuery)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	assert.T(t, reduced != nil)
-	assert.T(t, len(reduced) == 2)
-
-	teardownData(t, riak)
-}


### PR DESCRIPTION
This resolves #5 however the Search and Index tests do not cleanly pass.  I need to examine the API a little deeper to get a better understanding of it.

I have also completely rearranged `response.go`
1. unmarshalResponse() now handles everything in a switch statement.
2. I have ordered the cases so they match the numToCommand map.
3. I cleaned up some more areas where err was not getting correctly returned, shortened stuff up, etc.
4. It now handles RpbErrorResp and returns the actual error message which will allow us to get more descriptive database errors.

I would also recommend returning all of the raw `Rpb...Resp` structures as I have done with Search() and Index(), instead of just returning a specific field (as defined in response.go).  There is a lot of meta data a developer needs inside them.
