### PR TITLE
query index works, large changes to storeobject

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,8 @@
 package riakpbc
 
 import (
+	"encoding/json"
+	"log"
 	"testing"
 )
 
@@ -8,7 +10,16 @@ func BenchmarkReadSync(b *testing.B) {
 	b.StopTimer()
 	conn := New([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
 	conn.Dial()
-	conn.StoreObject("bucket", "key", []byte("{}"), "application/json")
+
+	data, err := json.Marshal(&Data{Data: "rules"})
+	if err != nil {
+		log.Println(err.Error())
+	}
+	content := &RpbContent{
+		Value:       data,
+		ContentType: []byte("application/json"),
+	}
+	conn.StoreObject("bucket", "key", content)
 
 	b.StartTimer()
 
@@ -21,7 +32,16 @@ func BenchmarkReadAsync(b *testing.B) {
 	b.StopTimer()
 	conn := New([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
 	conn.Dial()
-	conn.StoreObject("bucket", "key", []byte("{}"), "application/json")
+
+	data, err := json.Marshal(&Data{Data: "rules"})
+	if err != nil {
+		log.Println(err.Error())
+	}
+	content := &RpbContent{
+		Value:       data,
+		ContentType: []byte("application/json"),
+	}
+	conn.StoreObject("bucket", "key", content)
 
 	ch := make(chan bool, b.N)
 

--- a/query_test.go
+++ b/query_test.go
@@ -1,10 +1,15 @@
 package riakpbc
 
 import (
+	"encoding/json"
 	"github.com/bmizerany/assert"
 	"os/exec"
 	"testing"
 )
+
+type Farm struct {
+	Animal string `json:"animal"`
+}
 
 func setupIndexing(t *testing.T) {
 	cmd := exec.Command("search-cmd", "install", "riakpbctestbucket")
@@ -38,18 +43,79 @@ func TestMapReduce(t *testing.T) {
 
 func TestIndex(t *testing.T) {
 	riak := setupConnection(t)
-	setupData(t, riak)
+	d1, err := json.Marshal(&Farm{Animal: "chicken"})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	i1 := &RpbPair{
+		Key:   []byte("animal_bin"),
+		Value: []byte("chicken"),
+	}
+	c1 := &RpbContent{
+		Value:       d1,
+		ContentType: []byte("application/json"),
+		Indexes: []*RpbPair{
+			i1,
+		},
+	}
+	if _, err := riak.StoreObject("farm", "chicken", c1); err != nil {
+		t.Error(err.Error())
+	}
 
-	opts := &RpbIndexReq{Key: []byte("testkey")}
-	riak.SetOpts(opts)
-	data, err := riak.Index("riakpbctestbucket", "data_bin", 0)
+	d2, err := json.Marshal(&Farm{Animal: "hen"})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	i2 := &RpbPair{
+		Key:   []byte("animal_bin"),
+		Value: []byte("chicken"),
+	}
+	c2 := &RpbContent{
+		Value:       d2,
+		ContentType: []byte("application/json"),
+		Indexes: []*RpbPair{
+			i2,
+		},
+	}
+	if _, err := riak.StoreObject("farm", "hen", c2); err != nil {
+		t.Error(err.Error())
+	}
+
+	d3, err := json.Marshal(&Farm{Animal: "rooster"})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	i3 := &RpbPair{
+		Key:   []byte("animal_bin"),
+		Value: []byte("chicken"),
+	}
+	c3 := &RpbContent{
+		Value:       d3,
+		ContentType: []byte("application/json"),
+		Indexes: []*RpbPair{
+			i3,
+		},
+	}
+	if _, err := riak.StoreObject("farm", "rooster", c3); err != nil {
+		t.Error(err.Error())
+	}
+
+	data, err := riak.Index("farm", "animal_bin", "chicken", "", "")
 	if err != nil {
 		t.Log("In order for this test to pass storage_backend must be set to riak_kv_eleveldb_backend in app.config")
 		t.Error(err.Error())
 	}
 	assert.T(t, len(data.GetKeys()) > 0)
 
-	teardownData(t, riak)
+	if _, err := riak.DeleteObject("farm", "chicken"); err != nil {
+		t.Error(err.Error())
+	}
+	if _, err := riak.DeleteObject("farm", "hen"); err != nil {
+		t.Error(err.Error())
+	}
+	if _, err := riak.DeleteObject("farm", "rooster"); err != nil {
+		t.Error(err.Error())
+	}
 }
 
 func TestSearch(t *testing.T) {

--- a/riakpbc.go
+++ b/riakpbc.go
@@ -27,18 +27,17 @@ func (c *Conn) FetchObject(bucket, key string) (*RpbGetResp, error) {
 
 // StoreObject puts an object with ky into bucket.
 //
+// Content shoud be passed as a RpbContent struct.
+//
 // Pass RpbPutReq to SetOpts for optional parameters.
-func (c *Conn) StoreObject(bucket, key string, content []byte, contentType string) (*RpbPutResp, error) {
+func (c *Conn) StoreObject(bucket, key string, content *RpbContent) (*RpbPutResp, error) {
 	reqstruct := &RpbPutReq{}
 	if opts := c.Opts(); opts != nil {
 		reqstruct = opts.(*RpbPutReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
 	reqstruct.Key = []byte(key)
-	reqstruct.Content = &RpbContent{
-		Value:       content,
-		ContentType: []byte(contentType),
-	}
+	reqstruct.Content = content
 
 	if err := c.Request(reqstruct, "RpbPutReq"); err != nil {
 		return &RpbPutResp{}, err


### PR DESCRIPTION
Starting to get my head wrapped around the whole Riak PB interface now.

I have modified StoreObject so it's signature is the following:

```
func (c *Conn) StoreObject(bucket, key string, content *RpbContent) (*RpbPutResp, error)
```

RpbContent is another one of those things that open a lot of options up to the developer (indexes, links, etc.).

However!  It is a real pain to use these interfaces in such a raw fashion.  You get code that looks like the following (pulled from query_test.go):

```
d1, err := json.Marshal(&Farm{Animal: "chicken"})
if err != nil {
    t.Error(err.Error())
}
i1 := &RpbPair{
    Key:   []byte("animal_bin"),
    Value: []byte("chicken"),
}
c1 := &RpbContent{
    Value:       d1,
    ContentType: []byte("application/json"),
    Indexes: []*RpbPair{
        i1,
    },
}
if _, err := riak.StoreObject("farm", "chicken", c1); err != nil {
    t.Error(err.Error())
}
```

See #13 for the new riak Marshal implementation which makes the above code unnecessary.

This pull request works (the 2i Index search is now functional), but it did require the StoreObject parameter change.  That will change one more time if the other pull request is acceptable.
