### PR TITLE
Link Walking

### DIFF
--- a/coder.go
+++ b/coder.go
@@ -190,9 +190,6 @@ func (self *Coder) Marshal(data interface{}) (*RpbContent, error) {
 						}
 						out.Indexes = append(out.Indexes, index)
 						break
-					case "link":
-
-						break
 					}
 				}
 			}

--- a/err.go
+++ b/err.go
@@ -15,4 +15,5 @@ var (
 	ErrReadTimeout    = errors.New("read timeout")
 	ErrWriteTimeout   = errors.New("write timeout")
 	ErrZeroNodes      = errors.New("zero nodes in pool")
+	ErrNoContent      = errors.New("no content")
 )

--- a/link.go
+++ b/link.go
@@ -1,0 +1,59 @@
+package riakpbc
+
+// LinkAdd sets a link reference to the link bucket/key in bucket/key.
+//
+// Note that this can be manually done by passing RpbContent to StoreObject.
+func (c *Client) LinkAdd(bucket, key, lbucket, lkey, ltag string) error {
+	obj, err := c.FetchObject(bucket, key)
+	if err != nil {
+		return err
+	}
+
+	if len(obj.GetContent()) == 0 {
+		return ErrNoContent
+	}
+
+	link := &RpbLink{
+		Bucket: []byte(lbucket),
+		Key:    []byte(lkey),
+		Tag:    []byte(ltag),
+	}
+	obj.Content[0].Links = append(obj.Content[0].Links, link)
+
+	if _, err := c.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LinkWalk is just a synonymn for FetchObject.  It expects the link bucket/key.
+func (c *Client) LinkWalk(bucket, key string) (*RpbGetResp, error) {
+	return c.FetchObject(bucket, key)
+}
+
+// LinkRemove removes the associated link bucket/key from the bucket/key.
+func (c *Client) LinkRemove(bucket, key, lbucket, lkey string) error {
+	obj, err := c.FetchObject(bucket, key)
+	if err != nil {
+		return err
+	}
+
+	if len(obj.GetContent()) == 0 {
+		return ErrNoContent
+	}
+
+	for i, k := range obj.GetContent()[0].GetLinks() {
+		if string(k.GetBucket()) == lbucket && string(k.GetKey()) == lkey {
+			obj.Content[0].Links[i] = obj.Content[0].Links[len(obj.Content[0].Links)-1]
+			obj.Content[0].Links = obj.Content[0].Links[0 : len(obj.Content[0].Links)-1]
+			break
+		}
+	}
+
+	if _, err := c.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/link_test.go
+++ b/link_test.go
@@ -1,0 +1,55 @@
+package riakpbc
+
+import (
+	"testing"
+)
+
+func TestLink(t *testing.T) {
+	riak := setupConnection(t)
+	setupData(t, riak)
+
+	if _, err := riak.StoreObject("riakpbclinktestbucket1", "linktestkeyb1k1", "link start data"); err != nil {
+		t.Error(err.Error())
+	}
+
+	if _, err := riak.StoreObject("riakpbclinktestbucket2", "linktestkeyb2k1", "link next data"); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := riak.LinkAdd("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1", "riaklinktag"); err != nil {
+		t.Error(err.Error())
+	}
+
+	obj, err := riak.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if string(obj.GetContent()[0].GetLinks()[0].GetBucket()) != "riakpbclinktestbucket2" {
+		t.Error("expected link to riakpbclinktestbucket2")
+	}
+
+	link, err := riak.LinkWalk(string(obj.GetContent()[0].GetLinks()[0].GetBucket()), string(obj.GetContent()[0].GetLinks()[0].GetKey()))
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if string(link.GetContent()[0].GetValue()) != "link next data" {
+		t.Error("expected link walk to result in 'link next data'")
+	}
+
+	if err := riak.LinkRemove("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1"); err != nil {
+		t.Error(err.Error())
+	}
+
+	check, err := riak.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if len(check.GetContent()[0].GetLinks()) > 0 {
+		t.Error("expected links to be empty")
+	}
+
+	teardownData(t, riak)
+}


### PR DESCRIPTION
Fairly straightforward.

Not entirely sure if there is a better way to do this, it seems the only way to get full functionality out of everything is to continue to allow the developer to access the underlying Rpb\* objects.

Closes #24.
