### PR TITLE
Fixed Index Handling

### DIFF
--- a/query.go
+++ b/query.go
@@ -42,6 +42,9 @@ func (c *Client) Index(bucket, index, key, start, end string) (*RpbIndexResp, er
 
 	response, err := c.ReqResp(reqstruct, "RpbIndexReq", false)
 	if err != nil {
+		if err.Error() == "object not found" {
+			return &RpbIndexResp{}, nil
+		}
 		return nil, err
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -59,6 +59,12 @@ func TestIndex(t *testing.T) {
 	if _, err := riak.DeleteObject("farm", "rooster"); err != nil {
 		t.Error(err.Error())
 	}
+
+	// Search against a non-existent key should return empty, not error
+	check, err := riak.Index("farm", "animal_bin", "chicken", "", "")
+	if len(check.GetKeys()) > 0 {
+		t.Error("non-existent index search should return 0 results")
+	}
 }
 
 func TestSearch(t *testing.T) {


### PR DESCRIPTION
Returns an empty result instead of an error so no manual error checking for "object not found" has to occur on the dev side.

Fixes #26.
