### PR TITLE
Alternative Approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ As of June 21, 2013 the API is deemed relatively stable.  The library should be 
     	Field2 int    `json:"field2"`
     }
     
-    // Initialize riakpbc against a 3 node cluster
-    riak := NewClient([]string{"127.0.0.1:8087", "127.0.0.0:9089", "127.0.0.0:9090"})
-
     // Add optional coder for storing JSON data to/from structs
     // Alternative marshallers can be built from this interface
-    Coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
-    riak.SetCoder(Coder)
+    coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
+
+    // Initialize riakpbc against a 3 node cluster
+    riak := NewClient([]string{"127.0.0.1:8087", "127.0.0.0:9089", "127.0.0.0:9090"}, coder)
 
     // Dial all the nodes.
     if err := riak.Dial(); err != nil {
@@ -60,6 +59,9 @@ As of June 21, 2013 the API is deemed relatively stable.  The library should be 
     if err != nil {
         log.Println(err.Error())
     }
+
+    // All sessions must be Free'ed
+    riak.Free(session)
 
     // Close the connections if completely finished
     riak.Close()

--- a/bench_test.go
+++ b/bench_test.go
@@ -6,7 +6,7 @@ import (
 
 func BenchmarkReadSync(b *testing.B) {
 	b.StopTimer()
-	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
+	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"}, nil)
 	client.Dial()
 	session := client.Session()
 	session.StoreObject("bucket", "key", &Data{Data: "rules"})
@@ -20,7 +20,7 @@ func BenchmarkReadSync(b *testing.B) {
 
 func BenchmarkReadAsync(b *testing.B) {
 	b.StopTimer()
-	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
+	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"}, nil)
 	client.Dial()
 	session := client.Session()
 	session.StoreObject("bucket", "key", &Data{Data: "rules"})
@@ -31,7 +31,9 @@ func BenchmarkReadAsync(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		go func(node *Node) {
+			session := client.Session()
 			_, _ = node.FetchObject("bucket", "key")
+			client.Free(session)
 			select {
 			case ch <- true:
 			default:
@@ -46,7 +48,7 @@ func BenchmarkReadAsync(b *testing.B) {
 
 func BenchmarkStoreStruct(b *testing.B) {
 	b.StopTimer()
-	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
+	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"}, nil)
 	client.Dial()
 	session := client.Session()
 	session.StoreObject("bucket", "key", &Data{Data: "rules"})
@@ -60,7 +62,7 @@ func BenchmarkStoreStruct(b *testing.B) {
 
 func BenchmarkStoreRpbContent(b *testing.B) {
 	b.StopTimer()
-	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"})
+	client := NewClient([]string{"127.0.0.1:8087", "127.0.0.1:8088"}, nil)
 	client.Dial()
 	session := client.Session()
 

--- a/bucket.go
+++ b/bucket.go
@@ -1,10 +1,10 @@
 package riakpbc
 
 // List all buckets
-func (node *Node) ListBuckets() (*RpbListBucketsResp, error) {
+func (self *Node) ListBuckets() (*RpbListBucketsResp, error) {
 	reqdata := []byte{}
 
-	response, err := node.ReqResp(reqdata, "RpbListBucketsReq", true)
+	response, err := self.ReqResp(reqdata, "RpbListBucketsReq", true)
 	if err != nil {
 		return nil, err
 	}
@@ -13,12 +13,12 @@ func (node *Node) ListBuckets() (*RpbListBucketsResp, error) {
 }
 
 // List all keys from bucket
-func (node *Node) ListKeys(bucket string) ([][]byte, error) {
+func (self *Node) ListKeys(bucket string) ([][]byte, error) {
 	reqstruct := &RpbListKeysReq{
 		Bucket: []byte(bucket),
 	}
 
-	response, err := node.ReqMultiResp(reqstruct, "RpbListKeysReq")
+	response, err := self.ReqMultiResp(reqstruct, "RpbListKeysReq")
 	if err != nil {
 		return nil, err
 	}
@@ -29,12 +29,12 @@ func (node *Node) ListKeys(bucket string) ([][]byte, error) {
 }
 
 // Get bucket info
-func (node *Node) GetBucket(bucket string) (*RpbGetBucketResp, error) {
+func (self *Node) GetBucket(bucket string) (*RpbGetBucketResp, error) {
 	reqstruct := &RpbGetBucketReq{
 		Bucket: []byte(bucket),
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbGetBucketReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbGetBucketReq", false)
 	if err != nil {
 		return nil, err
 	}
@@ -43,9 +43,9 @@ func (node *Node) GetBucket(bucket string) (*RpbGetBucketResp, error) {
 }
 
 // Create bucket
-func (node *Node) SetBucket(bucket string, nval *uint32, allowmult *bool) ([]byte, error) {
+func (self *Node) SetBucket(bucket string, nval *uint32, allowmult *bool) ([]byte, error) {
 	reqstruct := &RpbSetBucketReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbSetBucketReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
@@ -55,7 +55,7 @@ func (node *Node) SetBucket(bucket string, nval *uint32, allowmult *bool) ([]byt
 		reqstruct.Props.AllowMult = allowmult
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbSetBucketReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbSetBucketReq", false)
 	if err != nil {
 		return nil, err
 	}

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -9,50 +9,53 @@ import (
 
 func TestListBuckets(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
-	buckets, err := riak.ListBuckets()
+	buckets, err := session.ListBuckets()
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, strings.Contains(buckets.String(), "riakpbctestbucket"))
 
 	teardownData(t, client)
+	client.Free(session)
 }
 
 func TestListKeys(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
-	keys, err := riak.ListKeys("riakpbctestbucket")
+	keys, err := session.ListKeys("riakpbctestbucket")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, strings.Contains(fmt.Sprintf("%s", keys), "testkey"))
 
 	teardownData(t, client)
+	client.Free(session)
 }
 
 func TestGetAndSetBuckets(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
 	nval := uint32(1)
 	allowmult := false
-	ok, err := riak.SetBucket("riakpbctestbucket", &nval, &allowmult)
+	ok, err := session.SetBucket("riakpbctestbucket", &nval, &allowmult)
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(ok) == "Success")
 
-	bucket, err := riak.GetBucket("riakpbctestbucket")
+	bucket, err := session.GetBucket("riakpbctestbucket")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, strings.Contains(string(bucket.GetProps().String()), "false"))
 
 	teardownData(t, client)
+	client.Free(session)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -11,13 +11,12 @@ type ExampleData struct {
 }
 
 func ExampleClient() {
-	// Initialize riakpbc against a 3 node cluster
-	riak := NewClient([]string{"127.0.0.1:8087", "127.0.0.0:9089", "127.0.0.0:9090"})
-
 	// Add optional coder for storing JSON data to/from structs
 	// Alternative marshallers can be built from this interface
-	Coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
-	riak.SetCoder(Coder)
+	coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
+
+	// Initialize riakpbc against a 3 node cluster
+	riak := NewClient([]string{"127.0.0.1:8087", "127.0.0.0:9089", "127.0.0.0:9090"}, coder)
 
 	// Dial all the nodes.
 	if err := riak.Dial(); err != nil {
@@ -63,6 +62,9 @@ func ExampleClient() {
 	fmt.Println(string(obj.GetContent()[0].GetValue()))
 	// Output:
 	// direct data
+
+	// All sessions must be Free'ed
+	riak.Free(session)
 
 	// Close the connections if completely finished
 	riak.Close()

--- a/link.go
+++ b/link.go
@@ -3,8 +3,8 @@ package riakpbc
 // LinkAdd sets a link reference to the link bucket/key in bucket/key.
 //
 // Note that this can be manually done by passing RpbContent to StoreObject.
-func (node *Node) LinkAdd(bucket, key, lbucket, lkey, ltag string) error {
-	obj, err := node.FetchObject(bucket, key)
+func (self *Node) LinkAdd(bucket, key, lbucket, lkey, ltag string) error {
+	obj, err := self.FetchObject(bucket, key)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func (node *Node) LinkAdd(bucket, key, lbucket, lkey, ltag string) error {
 	}
 	obj.Content[0].Links = append(obj.Content[0].Links, link)
 
-	if _, err := node.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
+	if _, err := self.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
 		return err
 	}
 
@@ -28,13 +28,13 @@ func (node *Node) LinkAdd(bucket, key, lbucket, lkey, ltag string) error {
 }
 
 // LinkWalk is just a synonymn for FetchObject.  It expects the link bucket/key.
-func (node *Node) LinkWalk(bucket, key string) (*RpbGetResp, error) {
-	return node.FetchObject(bucket, key)
+func (self *Node) LinkWalk(bucket, key string) (*RpbGetResp, error) {
+	return self.FetchObject(bucket, key)
 }
 
 // LinkRemove removes the associated link bucket/key from the bucket/key.
-func (node *Node) LinkRemove(bucket, key, lbucket, lkey string) error {
-	obj, err := node.FetchObject(bucket, key)
+func (self *Node) LinkRemove(bucket, key, lbucket, lkey string) error {
+	obj, err := self.FetchObject(bucket, key)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func (node *Node) LinkRemove(bucket, key, lbucket, lkey string) error {
 		}
 	}
 
-	if _, err := node.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
+	if _, err := self.StoreObject(bucket, key, obj.GetContent()[0]); err != nil {
 		return err
 	}
 

--- a/link_test.go
+++ b/link_test.go
@@ -6,22 +6,22 @@ import (
 
 func TestLink(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
-	if _, err := riak.StoreObject("riakpbclinktestbucket1", "linktestkeyb1k1", "link start data"); err != nil {
+	if _, err := session.StoreObject("riakpbclinktestbucket1", "linktestkeyb1k1", "link start data"); err != nil {
 		t.Error(err.Error())
 	}
 
-	if _, err := riak.StoreObject("riakpbclinktestbucket2", "linktestkeyb2k1", "link next data"); err != nil {
+	if _, err := session.StoreObject("riakpbclinktestbucket2", "linktestkeyb2k1", "link next data"); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := riak.LinkAdd("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1", "riaklinktag"); err != nil {
+	if err := session.LinkAdd("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1", "riaklinktag"); err != nil {
 		t.Error(err.Error())
 	}
 
-	obj, err := riak.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
+	obj, err := session.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -30,7 +30,7 @@ func TestLink(t *testing.T) {
 		t.Error("expected link to riakpbclinktestbucket2")
 	}
 
-	link, err := riak.LinkWalk(string(obj.GetContent()[0].GetLinks()[0].GetBucket()), string(obj.GetContent()[0].GetLinks()[0].GetKey()))
+	link, err := session.LinkWalk(string(obj.GetContent()[0].GetLinks()[0].GetBucket()), string(obj.GetContent()[0].GetLinks()[0].GetKey()))
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -39,11 +39,11 @@ func TestLink(t *testing.T) {
 		t.Error("expected link walk to result in 'link next data'")
 	}
 
-	if err := riak.LinkRemove("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1"); err != nil {
+	if err := session.LinkRemove("riakpbclinktestbucket1", "linktestkeyb1k1", "riakpbclinktestbucket2", "linktestkeyb2k1"); err != nil {
 		t.Error(err.Error())
 	}
 
-	check, err := riak.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
+	check, err := session.FetchObject("riakpbclinktestbucket1", "linktestkeyb1k1")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -53,4 +53,5 @@ func TestLink(t *testing.T) {
 	}
 
 	teardownData(t, client)
+	client.Free(session)
 }

--- a/object.go
+++ b/object.go
@@ -11,15 +11,15 @@ type RpbEmptyResp struct{}
 // FetchObject returns an object from a bucket and returns a RpbGetResp response.
 //
 // Pass RpbGetReq to SetOpts for optional parameters.
-func (node *Node) FetchObject(bucket, key string) (*RpbGetResp, error) {
+func (self *Node) FetchObject(bucket, key string) (*RpbGetResp, error) {
 	reqstruct := &RpbGetReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbGetReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
 	reqstruct.Key = []byte(key)
 
-	response, err := node.ReqResp(reqstruct, "RpbGetReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbGetReq", false)
 	if err != nil {
 		return nil, err
 	}
@@ -34,9 +34,9 @@ func (node *Node) FetchObject(bucket, key string) (*RpbGetResp, error) {
 // Use RpbContent if you need absolute control over what is going into Riak.
 //
 // Pass RpbPutReq to SetOpts for optional parameters.
-func (node *Node) StoreObject(bucket, key string, in interface{}) (*RpbPutResp, error) {
+func (self *Node) StoreObject(bucket, key string, in interface{}) (*RpbPutResp, error) {
 	reqstruct := &RpbPutReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbPutReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
@@ -74,7 +74,7 @@ func (node *Node) StoreObject(bucket, key string, in interface{}) (*RpbPutResp, 
 		return nil, errors.New("Invalid content type passed.  Must be RpbContent, string, int, or []byte")
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbPutReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbPutReq", false)
 	if err != nil {
 		return nil, err
 	}
@@ -85,15 +85,15 @@ func (node *Node) StoreObject(bucket, key string, in interface{}) (*RpbPutResp, 
 // DeleteObject removes object with key from bucket.
 //
 // Pass RpbDelReq to SetOpts for optional parameters.
-func (node *Node) DeleteObject(bucket, key string) ([]byte, error) {
+func (self *Node) DeleteObject(bucket, key string) ([]byte, error) {
 	reqstruct := &RpbDelReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbDelReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
 	reqstruct.Key = []byte(key)
 
-	response, err := node.ReqResp(reqstruct, "RpbDelReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbDelReq", false)
 	if err != nil {
 		return nil, err
 	}
@@ -104,19 +104,19 @@ func (node *Node) DeleteObject(bucket, key string) ([]byte, error) {
 // FetchStruct returns an object from a bucket and unmarshals it into the passed struct.
 //
 // Pass RpbGetReq to SetOpts for optional parameters.
-func (node *Node) FetchStruct(bucket, key string, out interface{}) (*RpbGetResp, error) {
-	if node.Coder == nil {
+func (self *Node) FetchStruct(bucket, key string, out interface{}) (*RpbGetResp, error) {
+	if self.coder == nil {
 		panic("Cannot fetch to a struct unless a coder has been set")
 	}
 
 	reqstruct := &RpbGetReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbGetReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
 	reqstruct.Key = []byte(key)
 
-	response, err := node.ReqResp(reqstruct, "RpbGetReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbGetReq", false)
 	if err != nil {
 		return &RpbGetResp{}, err
 	}
@@ -128,7 +128,7 @@ func (node *Node) FetchStruct(bucket, key string, out interface{}) (*RpbGetResp,
 		case reflect.Struct:
 			// TODO: This only returns the first result.
 			//  I believe the other possible results are related to vlocks, and will eventually need to be addressed.
-			err := node.Coder.Unmarshal(response.(*RpbGetResp).GetContent()[0].GetValue(), out)
+			err := self.coder.Unmarshal(response.(*RpbGetResp).GetContent()[0].GetValue(), out)
 			if err != nil {
 				return &RpbGetResp{}, err
 			}
@@ -145,13 +145,13 @@ func (node *Node) FetchStruct(bucket, key string, out interface{}) (*RpbGetResp,
 // Check Coder.Marshall() for `riak` tags that can be set on a structure for automated indexes and links.
 //
 // Pass RpbPutReq to SetOpts for optional parameters.
-func (node *Node) StoreStruct(bucket, key string, in interface{}) (*RpbPutResp, error) {
-	if node.Coder == nil {
+func (self *Node) StoreStruct(bucket, key string, in interface{}) (*RpbPutResp, error) {
+	if self.coder == nil {
 		panic("Cannot store a struct unless a coder has been set")
 	}
 
 	reqstruct := &RpbPutReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbPutReq)
 	}
 	reqstruct.Bucket = []byte(bucket)
@@ -167,7 +167,7 @@ func (node *Node) StoreStruct(bucket, key string, in interface{}) (*RpbPutResp, 
 			switch t.Elem().Kind() {
 			case reflect.Struct:
 				// Structs get passed through a marshaller
-				encctnt, err := node.Coder.Marshal(in)
+				encctnt, err := self.coder.Marshal(in)
 				if err != nil {
 					return nil, err
 				}
@@ -183,7 +183,7 @@ func (node *Node) StoreStruct(bucket, key string, in interface{}) (*RpbPutResp, 
 		return nil, errors.New("Invalid content type passed.  Must be struct, RpbContent, string, int, or []byte")
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbPutReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbPutReq", false)
 	if err != nil {
 		return nil, err
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -19,60 +19,60 @@ type RiakData struct {
 }
 
 func setupConnection(t *testing.T) *Client {
+	coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
 	client := NewClient([]string{"127.0.0.1:8087",
 		"127.0.0.1:8088",
 		"127.0.0.1:8087",
-		"127.0.0.1:8088"})
+		"127.0.0.1:8088"}, coder)
+
 	var err error
 	if err = client.Dial(); err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, err == nil)
-
-	Coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
-	client.SetCoder(Coder)
 
 	return client
 }
 
 func setupSingleNodeConnection(t *testing.T) *Client {
-	client := NewClient([]string{"127.0.0.1:8087"})
+	coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
+	client := NewClient([]string{"127.0.0.1:8087"}, coder)
+
 	var err error
 	if err = client.Dial(); err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, err == nil)
 
-	Coder := NewCoder("json", JsonMarshaller, JsonUnmarshaller)
-	client.SetCoder(Coder)
-
 	return client
 }
 
 func setupData(t *testing.T, client *Client) {
-	node := client.Session()
-	ok, err := node.StoreObject("riakpbctestbucket", "testkey", "{\"data\":\"is awesome!\"}")
+	session := client.Session()
+	ok, err := session.StoreObject("riakpbctestbucket", "testkey", "{\"data\":\"is awesome!\"}")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, len(ok.GetKey()) == 0)
+	client.Free(session)
 }
 
 func teardownData(t *testing.T, client *Client) {
-	node := client.Session()
-	ok, err := node.DeleteObject("riakpbctestbucket", "testkey")
+	session := client.Session()
+	ok, err := session.DeleteObject("riakpbctestbucket", "testkey")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(ok) == "Success")
+	client.Free(session)
 }
 
 func TestHead(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	userMeta := []*RpbPair{&RpbPair{Key: []byte("meta"), Value: []byte("schmeta")}}
 	rpbObj := &RpbContent{Value: []byte("rpbcontent data"), ContentType: []byte("text/plain"), Usermeta: userMeta}
-	_, err := riak.StoreObject("riakpbctestbucket", "testkey_rpbcontent", rpbObj)
+	_, err := session.StoreObject("riakpbctestbucket", "testkey_rpbcontent", rpbObj)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -81,60 +81,63 @@ func TestHead(t *testing.T) {
 	opts := &RpbGetReq{
 		Head: tB,
 	}
-	riak.SetOpts(opts)
-	obj, err := riak.FetchObject("riakpbctestbucket", "testkey_rpbcontent")
+	session.SetOpts(opts)
+	obj, err := session.FetchObject("riakpbctestbucket", "testkey_rpbcontent")
 	oObj := obj.GetContent()
 	assert.T(t, len(oObj) == 1)
 	content := oObj[0]
 	assert.T(t, len(content.GetValue()) == 0)
 	assert.T(t, len(content.GetUsermeta()) == 1)
 	assert.T(t, fmt.Sprintf("%s", content.GetUsermeta()[0]) == fmt.Sprintf("%s", &RpbPair{Key: []byte("meta"), Value: []byte("schmeta")}))
+	client.Free(session)
 }
 
 func TestStoreObject(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 
 	// Insert
-	_, err := riak.StoreObject("riakpbctestbucket", "testkey_rpbcontent", &RpbContent{Value: []byte("rpbcontent data"), ContentType: []byte("text/plain")})
+	_, err := session.StoreObject("riakpbctestbucket", "testkey_rpbcontent", &RpbContent{Value: []byte("rpbcontent data"), ContentType: []byte("text/plain")})
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.StoreObject("riakpbctestbucket", "testkey_string", "string data")
+	_, err = session.StoreObject("riakpbctestbucket", "testkey_string", "string data")
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.StoreObject("riakpbctestbucket", "testkey_int", 1000)
+	_, err = session.StoreObject("riakpbctestbucket", "testkey_int", 1000)
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.StoreObject("riakpbctestbucket", "testkey_binary", []byte("binary data"))
+	_, err = session.StoreObject("riakpbctestbucket", "testkey_binary", []byte("binary data"))
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Cleanup
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_rpbcontent")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_rpbcontent")
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_string")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_string")
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_int")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_int")
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_binary")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_binary")
 	if err != nil {
 		t.Error(err.Error())
 	}
+
+	client.Free(session)
 }
 
 func TestStoreStruct(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 
 	riak_data := &RiakData{
 		Email:   "riak@example.com",
@@ -142,20 +145,22 @@ func TestStoreStruct(t *testing.T) {
 		Data:    []byte("riak-data"),
 	}
 
-	_, err := riak.StoreStruct("riakpbctestbucket", "testkey_struct", riak_data)
+	_, err := session.StoreStruct("riakpbctestbucket", "testkey_struct", riak_data)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_struct")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_struct")
 	if err != nil {
 		t.Error(err.Error())
 	}
+
+	client.Free(session)
 }
 
 func TestStoreObjectWithOpts(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 
 	data, err := json.Marshal(&Data{Data: "is awesome!"})
 	if err != nil {
@@ -167,17 +172,19 @@ func TestStoreObjectWithOpts(t *testing.T) {
 	opts := &RpbPutReq{
 		ReturnBody: z,
 	}
-	riak.SetOpts(opts)
-	object, err := riak.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
+	session.SetOpts(opts)
+	object, err := session.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(object.GetContent()[0].GetValue()) == string(data))
 
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkeyopts")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkeyopts")
 	if err != nil {
 		t.Error(err.Error())
 	}
+
+	client.Free(session)
 }
 
 func TestConcurrentOpts(t *testing.T) {
@@ -191,24 +198,27 @@ func TestConcurrentOpts(t *testing.T) {
 	sym := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
 		go func() {
-			riak1 := client.Session()
+			session1 := client.Session()
 			z := new(bool)
 			*z = true
 			opts := &RpbPutReq{
 				ReturnBody: z,
 			}
-			riak1.SetOpts(opts)
-			object, err := riak1.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
+			session1.SetOpts(opts)
+			object, err := session1.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
 			if err != nil {
 				t.Error(err.Error())
 			}
 			assert.T(t, string(object.GetContent()[0].GetValue()) == string(data))
+			client.Free(session1)
 
-			riak2 := client.Session()
-			_, err = riak2.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
+			session2 := client.Session()
+			_, err = session2.StoreStruct("riakpbctestbucket", "testkeyopts", &Data{Data: "is awesome!"})
 			if err != nil {
 				t.Error(err.Error())
 			}
+			client.Free(session2)
+
 			sym <- true
 		}()
 	}
@@ -220,10 +230,10 @@ func TestConcurrentOpts(t *testing.T) {
 
 func TestFetchObject(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
-	object, err := riak.FetchObject("riakpbctestbucket", "testkey")
+	object, err := session.FetchObject("riakpbctestbucket", "testkey")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -236,11 +246,12 @@ func TestFetchObject(t *testing.T) {
 	assert.T(t, stringObject == data)
 
 	teardownData(t, client)
+	client.Free(session)
 }
 
 func TestFetchStruct(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
 	riak_data := &RiakData{
@@ -249,14 +260,14 @@ func TestFetchStruct(t *testing.T) {
 		Data:    []byte("riak-data"),
 	}
 
-	_, err := riak.StoreStruct("riakpbctestbucket", "testkey_struct", riak_data)
+	_, err := session.StoreStruct("riakpbctestbucket", "testkey_struct", riak_data)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	// Test
 	data := &RiakData{}
-	result, err := riak.FetchStruct("riakpbctestbucket", "testkey_struct", data)
+	result, err := session.FetchStruct("riakpbctestbucket", "testkey_struct", data)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -264,28 +275,30 @@ func TestFetchStruct(t *testing.T) {
 		t.Error("expected FetchStruct to also return RpbGetResp content")
 	}
 
-	_, err = riak.DeleteObject("riakpbctestbucket", "testkey_struct")
+	_, err = session.DeleteObject("riakpbctestbucket", "testkey_struct")
 	if err != nil {
 		t.Error(err.Error())
 	}
 
 	teardownData(t, client)
+	client.Free(session)
 }
 
 func TestDeleteObject(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 	setupData(t, client)
 
-	object, err := riak.DeleteObject("riakpbctestbucket", "testkey")
+	object, err := session.DeleteObject("riakpbctestbucket", "testkey")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(object) == "Success")
 
-	_, err = riak.FetchObject("riakpbctestbucket", "testkey")
+	_, err = session.FetchObject("riakpbctestbucket", "testkey")
 
 	assert.T(t, err.Error() == "object not found")
 
 	teardownData(t, client)
+	client.Free(session)
 }

--- a/pool.go
+++ b/pool.go
@@ -3,30 +3,39 @@ package riakpbc
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"time"
 )
 
+const (
+	NODE_ERROR_THRESHOLD float64 = 0.1
+	NODE_ERROR_MAX       float64 = 1.0
+)
+
 type Pool struct {
-	nodes   map[string]*Node // index the node with its address string
-	current *Node
-	sync.Mutex
+	nodes    map[string]*Node // index the node with its address string
+	nodePool chan *Node
 }
 
 // NewPool returns an instantiated pool given a slice of node addresses.
-func NewPool(cluster []string) *Pool {
+func NewPool(cluster []string, coder *Coder) *Pool {
 	rand.Seed(time.Now().UTC().UnixNano())
 	nodeMap := make(map[string]*Node, len(cluster))
 
 	for _, node := range cluster {
 		newNode, err := NewNode(node, 10e8, 10e8)
 		if err == nil {
+			newNode.coder = coder
 			nodeMap[node] = newNode
 		}
 	}
 
 	pool := &Pool{
-		nodes: nodeMap,
+		nodes:    nodeMap,
+		nodePool: make(chan *Node, len(nodeMap)),
+	}
+
+	for _, node := range nodeMap {
+		pool.nodePool <- node
 	}
 
 	return pool
@@ -37,62 +46,38 @@ func NewPool(cluster []string) *Pool {
 // Each node has an assignable error rate, which is incremented when an error
 // occurs, and decays over time - 50% each 10 seconds by default.
 func (pool *Pool) SelectNode() *Node {
-	pool.Lock()
-	errorThreshold := 0.1
-	var possibleNodes []*Node
-
-	for _, node := range pool.nodes {
-		nodeErrorValue := node.ErrorRate()
-
-		if nodeErrorValue < errorThreshold {
-			possibleNodes = append(possibleNodes, node)
-		} else {
-			if node.ok == false && node.ErrorRate() < 100.0 {
-				go func(iNode *Node) {
-					nodeGood := iNode.DoPing()
-					if nodeGood == false {
-						iNode.RecordError(100.0)
-						iNode.Lock()
-						iNode.Close()
-						iNode.Dial()
-						iNode.Unlock()
-					} else {
-						iNode.ok = true
-					}
-				}(node)
-			}
+	for {
+		// Pull a node off the pool and check it's health
+		node := <-pool.nodePool
+		if node.ok && node.ErrorRate() < NODE_ERROR_THRESHOLD {
+			return node
 		}
+		// Node is not ok
+		go func(p *Pool, n *Node) {
+			// Loop until we are alive again
+			for {
+				// If the node is back below the threshold try to ping/reconnect again
+				if n.ErrorRate() < NODE_ERROR_THRESHOLD {
+					if n.DoPing() == false {
+						// Still down, set back to max error
+						n.RecordError(NODE_ERROR_MAX)
+					} else {
+						// Attempt to redial the node
+						n.Close()
+						if err := n.Dial(); err == nil {
+							n.ok = true
+							p.nodePool <- n // push it back to the pool
+							return
+						}
+					}
+				}
+			}
+		}(pool, node)
 	}
-
-	numPossibleNodes := len(possibleNodes)
-
-	var chosenNode *Node
-	if numPossibleNodes > 0 {
-		chosenNode = possibleNodes[rand.Int31n(int32(numPossibleNodes))]
-	} else {
-		chosenNode = pool.RandomNode()
-	}
-	pool.Unlock()
-
-	return chosenNode
 }
 
-func (pool *Pool) RandomNode() *Node {
-	var randomNode *Node
-
-	var randVal float32
-	randVal = 0
-
-	for _, node := range pool.nodes {
-		throwAwayRand := rand.Float32()
-
-		if throwAwayRand > randVal {
-			randomNode = node
-			randVal = throwAwayRand
-		}
-	}
-
-	return randomNode
+func (pool *Pool) ReturnNode(node *Node) {
+	pool.nodePool <- node
 }
 
 func (pool *Pool) DeleteNode(nodeKey string) {

--- a/query.go
+++ b/query.go
@@ -6,13 +6,13 @@ package riakpbc
 //
 //    - application/json - JSON-encoded map/reduce job
 //    - application/x-erlang-binary - Erlang external term format
-func (node *Node) MapReduce(request, contentType string) ([]byte, error) {
+func (self *Node) MapReduce(request, contentType string) ([]byte, error) {
 	reqstruct := &RpbMapRedReq{
 		Request:     []byte(request),
 		ContentType: []byte(contentType),
 	}
 
-	response, err := node.ReqMultiResp(reqstruct, "RpbMapRedReq")
+	response, err := self.ReqMultiResp(reqstruct, "RpbMapRedReq")
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +23,7 @@ func (node *Node) MapReduce(request, contentType string) ([]byte, error) {
 // Index requests a set of keys that match a secondary index query.
 //
 //     qtype - an IndexQueryType of either 0 (eq) or 1 (range)
-func (node *Node) Index(bucket, index, key, start, end string) (*RpbIndexResp, error) {
+func (self *Node) Index(bucket, index, key, start, end string) (*RpbIndexResp, error) {
 	reqstruct := &RpbIndexReq{}
 	reqstruct.Bucket = []byte(bucket)
 	reqstruct.Index = []byte(index)
@@ -40,7 +40,7 @@ func (node *Node) Index(bucket, index, key, start, end string) (*RpbIndexResp, e
 		reqstruct.RangeMax = []byte(end)
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbIndexReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbIndexReq", false)
 	if err != nil {
 		if err.Error() == "object not found" {
 			return &RpbIndexResp{}, nil
@@ -54,15 +54,15 @@ func (node *Node) Index(bucket, index, key, start, end string) (*RpbIndexResp, e
 // Search scans bucket for query string q and searches index for the match.
 //
 // Pass RpbSearchQueryReq to SetOpts for optional parameters.
-func (node *Node) Search(index, q string) (*RpbSearchQueryResp, error) {
+func (self *Node) Search(index, q string) (*RpbSearchQueryResp, error) {
 	reqstruct := &RpbSearchQueryReq{}
-	if opts := node.Opts(); opts != nil {
+	if opts := self.Opts(); opts != nil {
 		reqstruct = opts.(*RpbSearchQueryReq)
 	}
 	reqstruct.Q = []byte(q)
 	reqstruct.Index = []byte(index)
 
-	response, err := node.ReqResp(reqstruct, "RpbSearchQueryReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbSearchQueryReq", false)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -1,10 +1,10 @@
 package riakpbc
 
 // Get server info
-func (node *Node) GetServerInfo() (*RpbGetServerInfoResp, error) {
+func (self *Node) GetServerInfo() (*RpbGetServerInfoResp, error) {
 	reqdata := []byte{}
 
-	response, err := node.ReqResp(reqdata, "RpbGetServerInfoReq", true)
+	response, err := self.ReqResp(reqdata, "RpbGetServerInfoReq", true)
 	if err != nil {
 		return nil, err
 	}
@@ -13,10 +13,10 @@ func (node *Node) GetServerInfo() (*RpbGetServerInfoResp, error) {
 }
 
 // Ping the server
-func (node *Node) Ping() ([]byte, error) {
+func (self *Node) Ping() ([]byte, error) {
 	reqdata := []byte{}
 
-	response, err := node.ReqResp(reqdata, "RpbPingReq", true)
+	response, err := self.ReqResp(reqdata, "RpbPingReq", true)
 	if err != nil {
 		return nil, err
 	}
@@ -25,10 +25,10 @@ func (node *Node) Ping() ([]byte, error) {
 }
 
 // Get client ID
-func (node *Node) GetClientId() (*RpbGetClientIdResp, error) {
+func (self *Node) GetClientId() (*RpbGetClientIdResp, error) {
 	reqdata := []byte{}
 
-	response, err := node.ReqResp(reqdata, "RpbGetClientIdReq", true)
+	response, err := self.ReqResp(reqdata, "RpbGetClientIdReq", true)
 	if err != nil {
 		return nil, err
 	}
@@ -37,12 +37,12 @@ func (node *Node) GetClientId() (*RpbGetClientIdResp, error) {
 }
 
 // Set client ID
-func (node *Node) SetClientId(clientId string) ([]byte, error) {
+func (self *Node) SetClientId(clientId string) ([]byte, error) {
 	reqstruct := &RpbSetClientIdReq{
 		ClientId: []byte(clientId),
 	}
 
-	response, err := node.ReqResp(reqstruct, "RpbSetClientIdReq", false)
+	response, err := self.ReqResp(reqstruct, "RpbSetClientIdReq", false)
 	if err != nil {
 		return nil, err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -7,39 +7,45 @@ import (
 
 func TestServerInfo(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 
-	info, err := riak.GetServerInfo()
+	info, err := session.GetServerInfo()
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, info != nil)
 	assert.T(t, string(info.GetServerVersion()) != "")
+
+	client.Free(session)
 }
 
 func TestPing(t *testing.T) {
 	client := setupConnection(t)
-	riak := client.Session()
+	session := client.Session()
 
-	pong, err := riak.Ping()
+	pong, err := session.Ping()
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(pong) == "Pong")
+
+	client.Free(session)
 }
 
 func TestClientId(t *testing.T) {
 	client := setupSingleNodeConnection(t)
-	riak := client.Session()
-	ok, err := riak.SetClientId("riakpbctestclientid")
+	session := client.Session()
+	ok, err := session.SetClientId("riakpbctestclientid")
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(ok) == "Success")
 
-	clientId, err := riak.GetClientId()
+	clientId, err := session.GetClientId()
 	if err != nil {
 		t.Error(err.Error())
 	}
 	assert.T(t, string(clientId.GetClientId()) != "")
+
+	client.Free(session)
 }

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -13,8 +13,8 @@ type Data struct {
 
 func main() {
 	runtime.GOMAXPROCS(7)
-	cluster := []string{"127.0.0.1:8087", "127.0.0.1:8088", "127.0.0.1:8089", "127.0.0.1:8090"}
-	client := riakpbc.NewClient(cluster)
+	cluster := []string{"127.0.0.1:8086", "127.0.0.1:8087", "127.0.0.1:8088", "127.0.0.1:8089", "127.0.0.1:8090"}
+	client := riakpbc.NewClient(cluster, nil)
 
 	err := client.Dial()
 	if err != nil {
@@ -43,7 +43,6 @@ func main() {
 					ReturnBody: z,
 				}
 
-				riak = client.Session()
 				riak.SetOpts(opts1)
 				_, err := riak.StoreObject("bucket", "data", "{'ok':'ok'}")
 				if err != nil {
@@ -79,7 +78,6 @@ func main() {
 					Head: z,
 				}
 
-				riak = client.Session()
 				riak.SetOpts(opts2)
 				_, err = riak.FetchObject("bucket", "moreData")
 				if err != nil {
@@ -88,6 +86,8 @@ func main() {
 
 				actionDuration := time.Now().Sub(actionBegin)
 				log.Print("<", which, "> @", times, " ", client.Pool(), "!<", errs, "> ", actionDuration)
+
+				client.Free(riak)
 			}
 		}(g)
 	}


### PR DESCRIPTION
@mrb This is an alternative approach to #33.

I like the way our current API exists because the opts don't get in the way unless the developer wants their full power.

What I did here was slide all the Riak Client logic down to Node, and made the small addition which requires a developer to call client.Session() once before they perform some actions (or multiple times inside a concurrent loop, for example).  This guarantees that opts set for the current session stick with the session, and don't get stomped due to concurrency.  It also had the side effect of reducing a handful of code calls.

This branch is complete and could be merged in to master unless you are still keen on pursuing #33 or other alternatives.
