### PR TITLE
Integer parsing on indexes fails

### DIFF
--- a/coder.go
+++ b/coder.go
@@ -1,11 +1,12 @@
 package riakpbc
 
 import (
-	"encoding/binary"
+	//"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -76,6 +77,9 @@ func NewCoder(tag string, marshaller MarshalMethod, unmarshaller UnmarshalMethod
 //
 // TODO: The PBC int interface doesn't seem to work directly with byte data, even though the API specification is byte data.
 // Needs to be investigated further.
+//
+// Update: August 3, 2013
+// Apparently the only way to get this to work is to treat _int index values as strings.
 func (self *Coder) Marshal(data interface{}) (*RpbContent, error) {
 	t := reflect.ValueOf(data)
 	if t.Kind() != reflect.Ptr {
@@ -117,29 +121,34 @@ func (self *Coder) Marshal(data interface{}) (*RpbContent, error) {
 							key = fld.Name + "_int"
 							switch knd {
 							case reflect.Int:
-								buf := make([]byte, 10)
-								binary.PutVarint(buf, int64(val.(int)))
-								index.Value = buf
+								//buf := make([]byte, 10)
+								//binary.PutVarint(buf, int64(val.(int)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(int))))
 								break
 							case reflect.Int8:
-								buf := make([]byte, 2)
-								binary.PutVarint(buf, int64(val.(int8)))
-								index.Value = buf
+								//buf := make([]byte, 2)
+								//binary.PutVarint(buf, int64(val.(int8)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(int8))))
 								break
 							case reflect.Int16:
-								buf := make([]byte, 3)
-								binary.PutVarint(buf, int64(val.(int16)))
-								index.Value = buf
+								//buf := make([]byte, 3)
+								//binary.PutVarint(buf, int64(val.(int16)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(int16))))
 								break
 							case reflect.Int32:
-								buf := make([]byte, 5)
-								binary.PutVarint(buf, int64(val.(int32)))
-								index.Value = buf
+								//buf := make([]byte, 5)
+								//binary.PutVarint(buf, int64(val.(int32)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(int32))))
 								break
 							case reflect.Int64:
-								buf := make([]byte, 10)
-								binary.PutVarint(buf, int64(val.(int64)))
-								index.Value = buf
+								//buf := make([]byte, 10)
+								//binary.PutVarint(buf, int64(val.(int64)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(int64))))
 								break
 							}
 							index.Key = []byte(strings.ToLower(key))
@@ -148,29 +157,34 @@ func (self *Coder) Marshal(data interface{}) (*RpbContent, error) {
 							key = fld.Name + "_int"
 							switch knd {
 							case reflect.Uint:
-								buf := make([]byte, 10)
-								binary.PutUvarint(buf, uint64(val.(uint)))
-								index.Value = buf
+								//buf := make([]byte, 10)
+								//binary.PutUvarint(buf, uint64(val.(uint)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(uint))))
 								break
 							case reflect.Uint8:
-								buf := make([]byte, 2)
-								binary.PutUvarint(buf, uint64(val.(uint8)))
-								index.Value = buf
+								//buf := make([]byte, 2)
+								//binary.PutUvarint(buf, uint64(val.(uint8)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(uint8))))
 								break
 							case reflect.Uint16:
-								buf := make([]byte, 3)
-								binary.PutUvarint(buf, uint64(val.(uint16)))
-								index.Value = buf
+								//buf := make([]byte, 3)
+								//binary.PutUvarint(buf, uint64(val.(uint16)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(uint16))))
 								break
 							case reflect.Uint32:
-								buf := make([]byte, 5)
-								binary.PutUvarint(buf, uint64(val.(uint32)))
-								index.Value = buf
+								//buf := make([]byte, 5)
+								//binary.PutUvarint(buf, uint64(val.(uint32)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(uint32))))
 								break
 							case reflect.Uint64:
-								buf := make([]byte, 10)
-								binary.PutUvarint(buf, uint64(val.(uint64)))
-								index.Value = buf
+								//buf := make([]byte, 10)
+								//binary.PutUvarint(buf, uint64(val.(uint64)))
+								//index.Value = buf
+								index.Value = []byte(strconv.Itoa(int(val.(uint64))))
 								break
 							}
 							index.Key = []byte(strings.ToLower(key))

--- a/object_test.go
+++ b/object_test.go
@@ -176,6 +176,38 @@ func TestStoreObjectWithOpts(t *testing.T) {
 	}
 }
 
+func TestStoreStructFullTypes(t *testing.T) {
+	riak := setupConnection(t)
+
+	data := EncodeData{
+		Email:   "riak@example.com",
+		Twitter: "riak-twitter",
+		Data:    []byte("riak-data"),
+		AnInt:   1,
+		AnInt8:  127,
+		AnInt16: 32767,
+		AnInt32: 2147483647,
+		AnInt64: 9223372036854775807,
+		AUInt:   1,
+		AUInt8:  255,
+		AUInt16: 65535,
+		AUInt32: 4294967295,
+		AUInt64: 18446744073709551615,
+		Byte:    255,
+		Rune:    2147483647,
+	}
+
+	_, err := riak.StoreStruct("riakpbctestbucket", "testfulltypes", &data)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_, err = riak.DeleteObject("riakpbctestbucket", "testfulltypes")
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestFetchObject(t *testing.T) {
 	riak := setupConnection(t)
 	setupData(t, riak)

--- a/object_test.go
+++ b/object_test.go
@@ -179,6 +179,7 @@ func TestStoreObjectWithOpts(t *testing.T) {
 func TestStoreStructFullTypes(t *testing.T) {
 	riak := setupConnection(t)
 
+	// Test struct from coder.go
 	data := EncodeData{
 		Email:   "riak@example.com",
 		Twitter: "riak-twitter",


### PR DESCRIPTION
Hey there, I'm getting a lot (%100 of my requests result in one) of these:

```
Error storing in Riak:  0: {precommit_fail,
    [{field_parsing_failed,{<<"images_int">>,<<6,0,0,0,0,0,0,0,0,0>>}},
     {field_parsing_failed,{<<"lastreply_int">>,<<0,0,0,0,0,0,0,0,0,0>>}},
     {field_parsing_failed,{<<"no_int">>,<<185,187,160,43,0,0,0,0,0,0>>}},
     {field_parsing_failed,{<<"replies_int">>,<<12,0,0,0,0,0,0,0,0,0>>}},
     {field_parsing_failed,
         {<<"tim_int">>,<<131,230,248,153,132,40,0,0,0,0>>}}]}
```

And here's my struct:

```
type Thread struct {
    Posts []Post `json:"posts"`
    No uint64 `riak:"index"`
    Replies     int `riak:"index"`
    Images     int `riak:"index"`
    Tim uint64 `riak:"index"`
    LastReply uint64 `riak:"index"`
}
```

Aaaand the code I'm using to insert it:

```
thread.No = thread.Posts[0].No
    thread.Replies = int(thread.Posts[0].Replies)
    thread.Images = int(thread.Posts[0].Images)
    thread.Tim = thread.Posts[0].Tim
    thread.LastReply = thread.Posts[len(thread.Posts)-1].Tim

    riakKey := fmt.Sprintf("t-%s-%d", board, thread.No)
    fmt.Println("Storing ", riakKey)

    _, err = RiakDBClient.StoreStruct("derpderp", riakKey, &thread)
    if err != nil {
        fmt.Println("Error storing in Riak: ", err)
    }
```
