### PR TITLE
Stop the background ping when the client has been closed.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -27,16 +27,3 @@ func TestBackgroundPingDoesNotCausePanicWhenClosed(t *testing.T) {
 	riak.Close()
 	riak.BackgroundNodePing()
 }
-
-func TestCallingCloseOnAClosedClientReturnsAnError(t *testing.T) {
-	defer func() {
-		if err := recover(); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	riak := clientTestSetupSingleNodeConnection(t)
-	riak.Close()
-	err := riak.Close()
-	assert.T(t, err != nil)
-}


### PR DESCRIPTION
The for-loop in BackgroundPing continued to run even after Close was called on the client. With a closed client the ping would cause Go to panic. The panic occurs because the node.conn field is set to nil when the node is closed and ping tries to use the field.

I've added a test that fails without the fix. I'm not sure if this is the best way to fix the problem. Checking whether the connection is closed at the Client level was less complicated than adding guard clauses around use of Pool and Node.
