### PR TITLE
Swapped Print/Println statements with Fatalf in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ func main() {
 
 	// Dial all the nodes.
 	if err := riak.Dial(); err != nil {
-		log.Print(err.Error())
+		log.Fatalf("Dialing failed: %v", err)
 	}
 
 	// Set Client ID
 	if _, err := riak.SetClientId("coolio"); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store raw data (int, string, []byte)
@@ -56,7 +56,7 @@ func main() {
 	// Set Client ID
 	opts1 := riak.NewSetClientIdRequest("coolio")
 	if _, err := riak.Do(opts1); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store raw data (int, string, []byte)
@@ -106,12 +106,12 @@ func main() {
 
 	// Dial all the nodes.
 	if err := riakCoder.Dial(); err != nil {
-		log.Print(err.Error())
+		log.Fatalf("Dialing failed: %v", err)
 	}
 
 	// Set Client ID
 	if _, err := riakCoder.SetClientId("coolio"); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store Struct (uses coder)

--- a/example_test.go
+++ b/example_test.go
@@ -16,12 +16,12 @@ func ExampleClient() {
 
 	// Dial all the nodes.
 	if err := riak.Dial(); err != nil {
-		log.Print(err.Error())
+		log.Fatalf("Dialing failed: %v", err)
 	}
 
 	// Set Client ID
 	if _, err := riak.SetClientId("coolio"); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store raw data (int, string, []byte)
@@ -43,7 +43,7 @@ func ExampleClient() {
 	// Set Client ID
 	opts1 := riak.NewSetClientIdRequest("coolio")
 	if _, err := riak.Do(opts1); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store raw data (int, string, []byte)
@@ -75,12 +75,12 @@ func ExampleClientWithCoder() {
 
 	// Dial all the nodes.
 	if err := riakCoder.Dial(); err != nil {
-		log.Print(err.Error())
+		log.Fatalf("Dialing failed: %v", err)
 	}
 
 	// Set Client ID
 	if _, err := riakCoder.SetClientId("coolio"); err != nil {
-		log.Println(err.Error())
+		log.Fatalf("Setting client ID failed: %v", err)
 	}
 
 	// Store Struct (uses coder)


### PR DESCRIPTION
According to the Go documentation, `Fatalf()` is equivalent to `Printf()` followed by a call to `os.Exit(1)`.

I opened this pull request because some of the individuals in `#go-nuts` expressed concern over logging errors and continuing on in the program.
