### PR TITLE
Fix null pointer dereference when server goes away

### DIFF
--- a/node.go
+++ b/node.go
@@ -159,7 +159,10 @@ func (node *Node) Ping() bool {
 
 // Close the connection
 func (node *Node) Close() {
-	node.conn.Close()
+	if node.conn != nil {
+		node.conn.Close()
+	}
+
 	node.conn = nil
 }
 


### PR DESCRIPTION
Fixes a panic when a node goes away.

How to reproduce:
- Start Riak
- Connect with mrb/riakpbc
- Stop Riak

Expected result:
- Nothing happens immediately, an error is returned on future requests if nodes are down

Actual result:
- Immediately panics on null pointer dereference
