### PR TITLE
Preserve multiple map-reduce responses independently

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,7 +164,7 @@ func (c *Client) ReqResp(reqstruct interface{}, structname string, raw bool) (re
 	if err != nil {
 		return nil, err
 	}
-	return node.ReqResp(reqstruct, structname, raw)
+	return node.ReqResp(reqstruct, structname, raw, false)
 }
 
 // ReqMultiResp is the top level interface for the client for the few

--- a/node.go
+++ b/node.go
@@ -83,9 +83,12 @@ func (node *Node) IsConnected() bool {
 	return node.conn != nil
 }
 
-func (node *Node) ReqResp(reqstruct interface{}, structname string, raw bool) (response interface{}, err error) {
-	node.Lock()
-	defer node.Unlock()
+func (node *Node) ReqResp(reqstruct interface{}, structname string, raw bool, locked bool) (response interface{}, err error) {
+	if !locked {
+		node.Lock()
+		defer node.Unlock()
+	}
+
 	if node.IsConnected() != true {
 		err = node.Dial()
 		if err != nil {
@@ -113,7 +116,10 @@ func (node *Node) ReqResp(reqstruct interface{}, structname string, raw bool) (r
 }
 
 func (node *Node) ReqMultiResp(reqstruct interface{}, structname string) (response interface{}, err error) {
-	response, err = node.ReqResp(reqstruct, structname, false)
+	node.Lock()
+	defer node.Unlock()
+
+	response, err = node.ReqResp(reqstruct, structname, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +149,12 @@ func (node *Node) ReqMultiResp(reqstruct interface{}, structname string) (respon
 		}
 		return mapResponse, nil
 	}
+
 	return nil, nil
 }
 
 func (node *Node) Ping() bool {
-	resp, err := node.ReqResp([]byte{}, "RpbPingReq", true)
+	resp, err := node.ReqResp([]byte{}, "RpbPingReq", true, false)
 	if err != nil {
 		return false
 	}

--- a/node.go
+++ b/node.go
@@ -131,15 +131,15 @@ func (node *Node) ReqMultiResp(reqstruct interface{}, structname string) (respon
 		}
 		return keys, nil
 	} else if structname == "RpbMapRedReq" {
-		mapResponse := response.(*RpbMapRedResp).GetResponse()
-		done := response.(*RpbMapRedResp).GetDone()
-		for done != true {
-			response, err := node.response()
-			if err != nil {
+		mapResponse := make([][]byte, 0)
+		for {
+			mapResponse = append(mapResponse, response.(*RpbMapRedResp).GetResponse())
+			if response.(*RpbMapRedResp).GetDone() {
+				break
+			}
+			if response, err = node.response(); err != nil {
 				return nil, err
 			}
-			mapResponse = append(mapResponse, response.(*RpbMapRedResp).GetResponse()...)
-			done = response.(*RpbMapRedResp).GetDone()
 		}
 		return mapResponse, nil
 	}

--- a/query.go
+++ b/query.go
@@ -8,7 +8,7 @@ func (c *Client) NewMapReduceRequest(request, contentType string) *RpbMapRedReq 
 	}
 }
 
-func (c *Client) mapReduce(opts *RpbMapRedReq, request, contentType string) ([]byte, error) {
+func (c *Client) mapReduce(opts *RpbMapRedReq, request, contentType string) ([][]byte, error) {
 	if opts == nil {
 		opts = c.NewMapReduceRequest(request, contentType)
 	}
@@ -18,7 +18,7 @@ func (c *Client) mapReduce(opts *RpbMapRedReq, request, contentType string) ([]b
 		return nil, err
 	}
 
-	return response.([]byte), nil
+	return response.([][]byte), nil
 }
 
 // MapReduce executes a MapReduce job.
@@ -27,7 +27,7 @@ func (c *Client) mapReduce(opts *RpbMapRedReq, request, contentType string) ([]b
 //
 //    - application/json - JSON-encoded map/reduce job
 //    - application/x-erlang-binary - Erlang external term format
-func (c *Client) MapReduce(request, contentType string) ([]byte, error) {
+func (c *Client) MapReduce(request, contentType string) ([][]byte, error) {
 	return c.mapReduce(nil, request, contentType)
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -27,7 +27,7 @@ func TestMapReduce(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	assert.T(t, string(reduced) == "[{\"data\":\"is awesome!\"}]")
+	assert.T(t, string(reduced[0]) == "[{\"data\":\"is awesome!\"}]")
 
 	teardownData(t, riak)
 }


### PR DESCRIPTION
This patch resolves an issue where multiple map-reduce responses are not preserved independently. The current behavior receives each response as a `[]byte` and appends it to the existing data (also a `[]byte`), resulting in a value that you can't always make sense of.

A simple scenario illustrating the problem:
- Our MR job will produce 3 JSON results from the final phase
- Riak sends those 3 results in 2 responses:

Response 1:

``` json
["{\"id\": 1}", "{\"id\": 2}"]
```

Response 2:

``` json
["{\"id\": 3}"]
```

The current behavior produces a result that is quite unusable:

``` json
["{\"id\": 1}", "{\"id\": 2}"]["{\"id\": 3}"]
```

This patch changes the return value of a map-reduce from `[]byte` to `[][]byte`, allowing the application to properly make sense of the data.
