### PR TITLE
The code.google.com repo isn't valid any more. Changed the protobuf to golang.org

### DIFF
--- a/node.go
+++ b/node.go
@@ -2,7 +2,7 @@ package riakpbc
 
 import (
 	"bytes"
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"encoding/binary"
 	"io"
 	"net"

--- a/response.go
+++ b/response.go
@@ -1,7 +1,7 @@
 package riakpbc
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"errors"
 	"strconv"
 )

--- a/riak.pb.go
+++ b/riak.pb.go
@@ -4,7 +4,7 @@
 
 package riakpbc
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/riak_kv.pb.go
+++ b/riak_kv.pb.go
@@ -4,7 +4,7 @@
 
 package riakpbc
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/riak_search.pb.go
+++ b/riak_search.pb.go
@@ -4,7 +4,7 @@
 
 package riakpbc
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 


### PR DESCRIPTION
Changed from `code.google.com/p/goprotobuf/proto` to 
`github.com/golang/protobuf/proto`
